### PR TITLE
Update codelql to use dotnet 9

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Setup .NET from global.json
       uses: actions/setup-dotnet@v4
       with:
-          global-json-file: ./global.json
+          dotnet-version: '9.0.x'
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3


### PR DESCRIPTION
# Summary of the Pull Request

**What is this about:** 
Codeql uses the global.json from Revit to define the dotnet to use. This led to errors when the version was missing.

**Description:** 
Defined the codeql donet version to pull the minor version of 9.0 that is available.

## Quality Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings